### PR TITLE
optimize NS

### DIFF
--- a/NetworkSkins/GUI/ButtonBar.cs
+++ b/NetworkSkins/GUI/ButtonBar.cs
@@ -68,7 +68,7 @@ namespace NetworkSkins.GUI
             base.Build(panelType, layout);
             CreateButtons();
             UIPanel space = AddUIComponent<UIPanel>();
-            space.size = new Vector2(width, 0.1f);
+            space.size = new Vector2(width, 1);
             Refresh();
         }
 

--- a/NetworkSkins/GUI/NetworkSkinPanel.cs
+++ b/NetworkSkins/GUI/NetworkSkinPanel.cs
@@ -53,7 +53,7 @@ namespace NetworkSkins.GUI
 
         private void EnsureToolbarOnScreen()
         {
-            Vector2 screenRes = UIView.GetAView().GetScreenResolution();
+            Vector2 screenRes = GetUIView().GetScreenResolution();
             if(relativePosition.x < 0f || relativePosition.x > screenRes.x || relativePosition.y < 0f || relativePosition.y > screenRes.y)
             {
                 relativePosition = CalculateDefaultToolbarPosition();
@@ -62,7 +62,7 @@ namespace NetworkSkins.GUI
 
         public override void Update() {
             base.Update();
-            Vector2 screenRes = UIView.GetAView().GetScreenResolution();
+            Vector2 screenRes = GetUIView().GetScreenResolution();
 
             if ((autoLayoutStart == LayoutStart.TopLeft  || autoLayoutStart == LayoutStart.BottomLeft) && relativePosition.x > screenRes.x / 2.0f) {
                 autoLayoutStart = autoLayoutStart == LayoutStart.TopLeft ? LayoutStart.TopRight : LayoutStart.BottomRight;


### PR DESCRIPTION
fixed fractional size to save 300ms every time panel is created.
used `GetUIView()` (which is cached) in the `Update()` method instead of `UIView.GetAView()` which creates garbage every frame.
